### PR TITLE
Patch: get secrets id using a query parameter

### DIFF
--- a/snappass/main.py
+++ b/snappass/main.py
@@ -188,25 +188,25 @@ def handle_password():
             base_url = request.url_root.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
-    link = base_url + url_quote_plus(token)
+    link = f"{base_url}retrieve?password_key={url_quote_plus(token)}"
     if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
         return jsonify(link=link, ttl=ttl)
     else:
         return render_template('confirm.html', password_link=link)
 
 
-@app.route('/<password_key>', methods=['GET'])
-def preview_password(password_key):
-    password_key = url_unquote_plus(password_key)
+@app.route('/retrieve', methods=['GET'])
+def preview_password():
+    password_key = request.args.to_dict().get("password_key")
     if not password_exists(password_key):
         return render_template('expired.html'), 404
 
     return render_template('preview.html')
 
 
-@app.route('/<password_key>', methods=['POST'])
-def show_password(password_key):
-    password_key = url_unquote_plus(password_key)
+@app.route('/retrieve', methods=['POST'])
+def show_password():
+    password_key = request.args.to_dict().get("password_key")
     password = get_password(password_key)
     if not password:
         return render_template('expired.html'), 404

--- a/snappass/templates/base.html
+++ b/snappass/templates/base.html
@@ -28,6 +28,16 @@
         _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
         _paq.push(["setTrackerUrl", u + "/matomo.php"]);
         _paq.push(["setSiteId", "{{site_id}}"]);
+
+        // remove query parameters before sending the url to matomo
+        let page_url = location.href;
+        const query_pos = location.href.indexOf("?");
+        if (query_pos) {
+          page_url = location.href.substring(0, query_pos);
+        }
+        _paq.push(["setCustomUrl", page_url]);
+        _paq.push(["trackPageView"]);
+
         let d = document,
           g = d.createElement("script"),
           s = d.getElementsByTagName("script")[0];


### PR DESCRIPTION
Utilize query parameters for password key fetching, and disable sending the query parameter with the password key to Matomo.

Closes #35 